### PR TITLE
Update development infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 mdv-*.gem
+coverage/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ require:
   - rubocop-performance
 
 AllCops:
+  Exclude:
+    - 'vendor/bundle/**/*'
   NewCops: enable
   TargetRubyVersion: 2.5
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.5
 
+# Make BeginEndAlignment behavior match EndAlignment
+Layout/BeginEndAlignment:
+  EnforcedStyleAlignWith: begin
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 require:
+  - rubocop-minitest
+  - rubocop-packaging
   - rubocop-performance
 
 AllCops:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: ruby
 
 dist: xenial
@@ -21,10 +22,17 @@ before_install:
 cache:
   bundler: true
 
-rvm:
-  - 2.5
-  - 2.6
-  - 2.7
+script: bundle exec rake
+
+jobs:
+  include:
+    - rvm: 2.5
+    - rvm: 2.6
+    - rvm: 2.7
+    - rvm: 2.7.1
+      name: "RuboCop"
+      before_install: []
+      script: bundle exec rubocop
 
 branches:
   only:

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,0 +1,8 @@
+lib/mdv
+lib/mdv.rb
+lib/mdv/document.rb
+lib/mdv/markdown_viewer.rb
+LICENSE
+Changelog.md
+README.md
+bin/mdv

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@
 require "rake/clean"
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "rake/manifest"
 
 namespace :test do
   Rake::TestTask.new(:unit) do |t|
@@ -19,7 +20,11 @@ namespace :test do
 
   task all: [:unit, :end_to_end]
 end
-
 task test: "test:all"
+
+Rake::Manifest::Task.new do |t|
+  t.patterns = ["lib/**/*", "LICENSE", "*.md", "bin/*"]
+end
+task build: "manifest:check"
 
 task default: "test"

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -34,5 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.1.0"
   spec.add_development_dependency "rubocop", "~> 0.92.0"
+  spec.add_development_dependency "rubocop-minitest", "~> 0.10.1"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.8.0"
 end

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -1,29 +1,36 @@
 # frozen_string_literal: true
 
-Gem::Specification.new do |s|
-  s.name = "mdv"
-  s.version = "0.5.1"
+Gem::Specification.new do |spec|
+  spec.name = "mdv"
+  spec.version = "0.5.1"
+  spec.authors = ["Matijs van Zuijlen"]
+  spec.email = ["matijs@matijs.net"]
 
-  s.summary = "Simple Markdown Viewer"
-  s.description = "Quickly view markdown files on GNOME"
-  s.required_ruby_version = ">= 2.5.0"
+  spec.summary = "Simple Markdown Viewer"
+  spec.description = <<~DESC
+    Quickly view markdown files on GNOME
+  DESC
+  spec.homepage = "http://www.github.com/mvz/mdv"
+  spec.license = "MIT"
 
-  s.authors = ["Matijs van Zuijlen"]
-  s.email = ["matijs@matijs.net"]
-  s.homepage = "http://www.github.com/mvz/mdv"
+  spec.required_ruby_version = ">= 2.5.0"
 
-  s.executables = ["mdv"]
-  s.files =
-    Dir["bin/*", "*.md", "LICENSE", "Rakefile", "Gemfile", "lib/**/*.rb"] &
-    `git ls-files -z`.split("\0")
-  s.test_files = Dir["test/**/*.rb"]
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/mvz/mdv"
+  spec.metadata["changelog_uri"] = "https://github.com/mvz/mdv/blob/master/Changelog.md"
 
-  s.license = "MIT"
+  spec.files = File.read("Manifest.txt").split
+  spec.rdoc_options = ["--main", "README.md"]
+  spec.extra_rdoc_files = ["Changelog.md", "README.md"]
+  spec.require_paths = ["lib"]
+  spec.executables = ["mdv"]
 
-  s.add_dependency("gir_ffi-gtk", ["~> 0.15.0"])
-  s.add_dependency("github-markdown", ["~> 0.6.5"])
-  s.add_dependency("github-markup", ["~> 3.0"])
-  s.add_development_dependency("atspi_app_driver", ["~> 0.6.0"])
-  s.add_development_dependency("minitest", ["~> 5.12"])
-  s.add_development_dependency("rake", ["~> 13.0"])
+  spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.15.0"
+  spec.add_runtime_dependency "github-markdown", "~> 0.6.5"
+  spec.add_runtime_dependency "github-markup", "~> 3.0"
+
+  spec.add_development_dependency "atspi_app_driver", "~> 0.6.0"
+  spec.add_development_dependency "minitest", "~> 5.12"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.1.0"
 end

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.1.0"
+  spec.add_development_dependency "rubocop", "~> 0.92.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.8.0"
 end

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-minitest", "~> 0.10.1"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.8.0"
+  spec.add_development_dependency "simplecov", "~> 0.19.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,10 @@
 # frozen_string_literal: true
 
+require "simplecov"
+SimpleCov.start do
+  add_group "Main", "lib"
+  add_group "Tests", "test"
+  enable_coverage :branch
+end
+
 require "minitest/autorun"


### PR DESCRIPTION
Update gem infrastructure:
- Update gemspec to match current format generated by `bundle gem`
- Use rake-manifest to maintain a manifest of files to include

RuboCop:
- Add rubocop gems as development dependencies
- Configure BeginEndAlignment cop to match EndAlignment
- Add more rubocop cop collections

Other:
- Add simplecov
- Configure Dependabot
- Run RuboCop on Travis as a separate job