### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.14.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.26"
+  spec.add_development_dependency "rubocop", "~> 1.51"
   spec.add_development_dependency "rubocop-minitest", "~> 0.31.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.13"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
+  spec.add_development_dependency "rubocop-performance", "~> 1.18"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end


### PR DESCRIPTION
- Bump versions for rubocop dependencies
- Require development dependencies to be in the gemspec
