### PR TITLE
Switch to commonmarker as the Markdown renderer

### DIFF
--- a/lib/mdv/document.rb
+++ b/lib/mdv/document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "github/markup"
+require "commonmarker"
 
 module MDV
   # Markdown document class
@@ -14,7 +14,10 @@ module MDV
     end
 
     def html
-      GitHub::Markup.render(fullpath, File.read(fullpath))
+      content = File.read(fullpath)
+      commonmarker_opts = [:GITHUB_PRE_LANG]
+      commonmarker_exts = [:tagfilter, :autolink, :table, :strikethrough]
+      CommonMarker.render_html(content, commonmarker_opts, commonmarker_exts)
     end
 
     private

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
+  spec.add_runtime_dependency "commonmarker", "~> 0.23.10"
   spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
   spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.17.0"
-  spec.add_runtime_dependency "github-markdown", "~> 0.6.5"
   spec.add_runtime_dependency "github-markup", ">= 3", "< 5"
 
   spec.add_development_dependency "atspi_app_driver", "~> 0.9.0"

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "commonmarker", "~> 0.23.10"
   spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
   spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.17.0"
-  spec.add_runtime_dependency "github-markup", ">= 3", "< 5"
 
   spec.add_development_dependency "atspi_app_driver", "~> 0.9.0"
   spec.add_development_dependency "minitest", "~> 5.12"

--- a/test/fixtures/README.html
+++ b/test/fixtures/README.html
@@ -1,0 +1,40 @@
+<h1>MDV</h1>
+
+<p>Simple Markdown Viewer for GNOME 3.</p>
+
+<h2>Usage</h2>
+
+<pre><code>mdv README.md
+</code></pre>
+
+<p>Press Ctrl-R to reload, Ctrl-Q to quit, Ctrl-C to copy selected text. Clicked
+links open in default browser.</p>
+
+<h2>Install</h2>
+
+<pre><code>gem install mdv
+</code></pre>
+
+<h2>Dependencies</h2>
+
+<p>MDV depends on the <code>gir_ffi-gtk</code> gem. Additionally, you need to install the
+Webkit2Gtk library and its gobject-introspection information. On Debian and
+Ubuntu, the following should work:</p>
+
+<pre><code>sudo apt-get install gir1.2-webkit2-4.0
+</code></pre>
+
+<p>On Ubuntu, you may also have to install two additional packages:</p>
+
+<pre><code>sudo apt-get install libwebkit2gtk-4.0-dev libjavascriptcoregtk-4.0-dev
+</code></pre>
+
+<h2>Contributing</h2>
+
+<p>Contributions are welcome! Please feel free to create issues or pull requests
+on GitHub.</p>
+
+<h2>License</h2>
+
+<p>Copyright &copy; 2012&ndash;2019 <a href="http://www.matijs.net">Matijs van Zuijlen</a>.
+See LICENSE for details.</p>

--- a/test/fixtures/README.html
+++ b/test/fixtures/README.html
@@ -1,40 +1,25 @@
 <h1>MDV</h1>
-
 <p>Simple Markdown Viewer for GNOME 3.</p>
-
 <h2>Usage</h2>
-
 <pre><code>mdv README.md
 </code></pre>
-
 <p>Press Ctrl-R to reload, Ctrl-Q to quit, Ctrl-C to copy selected text. Clicked
 links open in default browser.</p>
-
 <h2>Install</h2>
-
 <pre><code>gem install mdv
 </code></pre>
-
 <h2>Dependencies</h2>
-
 <p>MDV depends on the <code>gir_ffi-gtk</code> gem. Additionally, you need to install the
 Webkit2Gtk library and its gobject-introspection information. On Debian and
 Ubuntu, the following should work:</p>
-
 <pre><code>sudo apt-get install gir1.2-webkit2-4.0
 </code></pre>
-
 <p>On Ubuntu, you may also have to install two additional packages:</p>
-
 <pre><code>sudo apt-get install libwebkit2gtk-4.0-dev libjavascriptcoregtk-4.0-dev
 </code></pre>
-
 <h2>Contributing</h2>
-
 <p>Contributions are welcome! Please feel free to create issues or pull requests
 on GitHub.</p>
-
 <h2>License</h2>
-
-<p>Copyright &copy; 2012&ndash;2019 <a href="http://www.matijs.net">Matijs van Zuijlen</a>.
+<p>Copyright © 2012–2019 <a href="http://www.matijs.net">Matijs van Zuijlen</a>.
 See LICENSE for details.</p>

--- a/test/mdv/document_test.rb
+++ b/test/mdv/document_test.rb
@@ -12,7 +12,7 @@ describe MDV::Document do
   describe "#html" do
     it "renders the correct html" do
       _(document.html)
-        .must_equal "<h1>Test</h1>\n\n<p>This is a test document.</p>\n"
+        .must_equal "<h1>Test</h1>\n<p>This is a test document.</p>\n"
     end
 
     it "renders the correct html for this project's README" do

--- a/test/mdv/document_test.rb
+++ b/test/mdv/document_test.rb
@@ -5,12 +5,20 @@ require_relative "../test_helper"
 require "mdv/document"
 
 describe MDV::Document do
-  let(:document) { MDV::Document.new("test/fixtures/test.md") }
+  let(:fixtures_dir) { File.expand_path("../fixtures/", __dir__) }
+  let(:document) { MDV::Document.new(File.join(fixtures_dir, "test.md")) }
+  let(:readme) { MDV::Document.new(File.expand_path("../../README.md", __dir__)) }
 
   describe "#html" do
     it "renders the correct html" do
       _(document.html)
         .must_equal "<h1>Test</h1>\n\n<p>This is a test document.</p>\n"
+    end
+
+    it "renders the correct html for this project's README" do
+      expected = File.read File.join(fixtures_dir, "README.html")
+
+      _(readme.html).must_equal expected
     end
   end
 end


### PR DESCRIPTION
This fixes a problem where having commonmarker 1.0 installed would break mdv because github-markup would load it instead of github-markdown. Since github-markup does not in fact work with commonmarker 1.0 at the moment, rendering the markdown would fail. On the other hand, commonmarker 1.0 requires Ruby 3.1, so, since we still support 3.0 right now, we stick to version 0.23.10

- Add test for larger HTML rendering
- Replace github-markdown with commonmarker
- Switch to using commonmarker directly