### PR TITLE
Switch to latest commonmarker version

### DIFF
--- a/lib/mdv/document.rb
+++ b/lib/mdv/document.rb
@@ -15,9 +15,15 @@ module MDV
 
     def html
       content = File.read(fullpath)
-      commonmarker_opts = [:GITHUB_PRE_LANG]
-      commonmarker_exts = [:tagfilter, :autolink, :table, :strikethrough]
-      CommonMarker.render_html(content, commonmarker_opts, commonmarker_exts)
+      Commonmarker.to_html(content,
+        options: {
+          render: {hardbreaks: false},
+          extension: {tagfilter: true,
+                      autolink: true,
+                      table: true,
+                      strikethrough: true}
+        },
+        plugins: {})
     end
 
     private

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
-  spec.add_runtime_dependency "commonmarker", "~> 0.23.10"
+  spec.add_runtime_dependency "commonmarker", "~> 1.0"
   spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
   spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.17.0"
 


### PR DESCRIPTION
Now that support for Ruby 3.0 has been dropped we can switch to commonmarker 1.0.
