### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
-  spec.add_runtime_dependency "commonmarker", "~> 1.0"
-  spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
-  spec.add_runtime_dependency "gir_ffi-gtk", "~> 0.17.0"
+  spec.add_dependency "commonmarker", "~> 1.0"
+  spec.add_dependency "gir_ffi", "~> 0.17.0"
+  spec.add_dependency "gir_ffi-gtk", "~> 0.17.0"
 
   spec.add_development_dependency "atspi_app_driver", "~> 0.9.0"
   spec.add_development_dependency "minitest", "~> 5.12"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
