### PR TITLE
Upgrade commonmarker dependency

### DIFF
--- a/lib/mdv/document.rb
+++ b/lib/mdv/document.rb
@@ -16,13 +16,12 @@ module MDV
     def html
       content = File.read(fullpath)
       Commonmarker.to_html(content,
-        options: {
-          render: {hardbreaks: false},
-          extension: {tagfilter: true,
-                      autolink: true,
-                      table: true,
-                      strikethrough: true}
-        },
+        options: {render: {hardbreaks: false},
+                  extension: {tagfilter: true,
+                              autolink: true,
+                              table: true,
+                              strikethrough: true,
+                              header_ids: nil}},
         plugins: {})
     end
 

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "atspi_app_driver", "~> 0.9.0"
   spec.add_development_dependency "minitest", "~> 5.12"
+  spec.add_development_dependency "minitest-focus", "~> 1.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rubocop", "~> 1.51"

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
-  spec.add_dependency "commonmarker", "~> 1.0"
+  spec.add_dependency "commonmarker", "~> 2.0"
   spec.add_dependency "gir_ffi", "~> 0.17.0"
   spec.add_dependency "gir_ffi-gtk", "~> 0.17.0"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,3 +8,4 @@ SimpleCov.start do
 end
 
 require "minitest/autorun"
+require "minitest/focus"


### PR DESCRIPTION
- Add minitest-focus gem to ease development
- Upgrade commonmarker gem to version 2.0
