### PR TITLE
Update RuboCop configuration and handle new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,10 @@ Lint/AmbiguousOperatorPrecedence:
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
+# This cop has too many false positives
+Naming/PredicateMethod:
+  Enabled: false
+
 Performance/StartWith:
   AutoCorrect: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-focus", "~> 1.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/test/end_to_end/basic_run_test.rb
+++ b/test/end_to_end/basic_run_test.rb
@@ -25,6 +25,7 @@ describe "The MDV application" do
     frame.find_role(:menu_item, /Quit/).do_action 0
 
     status = @driver.cleanup
+
     _(status.exitstatus).must_equal 0
   end
 


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
- Disable Naming/PredicateMethod cop
