### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ plugins:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/mdv"
 
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/mdv"


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Remove Ruby 3.1 from the CI matrix**
