### PR TITLE
Update gir_ffi and gir_ffi-gtk dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,6 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
 
-# Put development dependencies in the gemspec so rubygems.org knows about them
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec
-
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 group :development, :test do
-  gem "atspi_app_driver", "~> 0.10.0"
+  gem "atspi_app_driver", "~> 0.11.0"
   gem "minitest", "~> 6.0"
   gem "minitest-focus", "~> 1.4"
   gem "rake", "~> 13.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,17 @@
 
 source "https://rubygems.org"
 
+group :development, :test do
+  gem "atspi_app_driver", "~> 0.10.0"
+  gem "minitest", "~> 6.0"
+  gem "minitest-focus", "~> 1.4"
+  gem "rake", "~> 13.0"
+  gem "rake-manifest", "~> 0.2.0"
+  gem "rubocop", "~> 1.79"
+  gem "rubocop-minitest", "~> 0.39.1"
+  gem "rubocop-packaging", "~> 0.6.0"
+  gem "rubocop-performance", "~> 1.25"
+  gem "simplecov", "~> 0.22.0"
+end
+
 gemspec

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -33,15 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "commonmarker", "~> 2.0"
   spec.add_dependency "gir_ffi", "~> 0.18.0"
   spec.add_dependency "gir_ffi-gtk", "~> 0.18.0"
-
-  spec.add_development_dependency "atspi_app_driver", "~> 0.10.0"
-  spec.add_development_dependency "minitest", "~> 6.0"
-  spec.add_development_dependency "minitest-focus", "~> 1.4"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.79"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.39.1"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.25"
-  spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/mdv.gemspec
+++ b/mdv.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["Changelog.md", "README.md"]
 
   spec.add_dependency "commonmarker", "~> 2.0"
-  spec.add_dependency "gir_ffi", "~> 0.18.0"
-  spec.add_dependency "gir_ffi-gtk", "~> 0.18.0"
+  spec.add_dependency "gir_ffi", "~> 0.19.0"
+  spec.add_dependency "gir_ffi-gtk", "~> 0.19.0"
 end


### PR DESCRIPTION
- **Move development dependencies to the Gemfile**
- **Update gir_ffi and gir_ffi-gtk dependencies to 0.19.0**
